### PR TITLE
Make retest command work with multiple workflows

### DIFF
--- a/.github/actions/retest-action/entrypoint.sh
+++ b/.github/actions/retest-action/entrypoint.sh
@@ -70,40 +70,66 @@ BRANCH=$(jq -r '.head.ref' pr.json)
 curl --request GET \
     --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?event=pull_request&actor=${ACTOR}&branch=${BRANCH}" \
     --header "authorization: Bearer ${GITHUB_TOKEN}" \
-    --header "content-type: application/json" | jq '.workflow_runs | max_by(.run_number)' > run.json
+    --header "content-type: application/json" |\
+    jq '.workflow_runs |
+        group_by(.name) | 
+        map(max_by(.run_number)) | 
+    ' > workflow_runs.json
 
-ACTION_URL=""
+
 if [ "$ACTION" == "/retest" ]; then
-  ACTION_URL=$(jq -r '.rerun_url' run.json)
+  cat workflow_runs.json |\
+    jq -r '.[] |
+      map(select(.status|contains("completed"))) |
+      .[] | .rerun_url
+    ' > url.data
 elif [ "$ACTION" == "/retest-failed" ]; then
   # New feature, rerun failed jobs:
   # https://docs.github.com/en/rest/reference/actions#re-run-failed-jobs-from-a-workflow-run
-  RERUN_URL=$(jq -r '.rerun_url' run.json)
-  ACTION_URL=${RERUN_URL}-failed-jobs
+  cat workflow_runs.json |\
+    jq -r '
+      map(select(.status|contains("completed"))) |
+      map(select(.conclusion|contains("failure"))) |
+      .[] | .rerun_url + "-failed-jobs"
+    ' > url.data
 elif [ "$ACTION" == "/cancel" ]; then
-  ACTION_URL=$(jq -r '.cancel_url' run.json)
+  cat workflow_runs.json |\
+    jq -r '
+      map(select(.status | test ("queued|in_progress|pending" )) |
+      .[] | .cancel_url
+    ' > url.data
 else
   echo "Something went wrong, unsupported action"
   exit 0
 fi
 
-# Execute the action.
-# Store the response code in a variable.
-# Store the answer in file .action-response.json.
-RESPONSE_CODE=$(curl --write-out '%{http_code}' --silent --output .action-response.json --request POST \
-    --url "${ACTION_URL}" \
-    --header "authorization: Bearer ${GITHUB_TOKEN}" \
-    --header "content-type: application/json")
-
-
 REACTION_SYMBOL="rocket"
-if ! echo ${RESPONSE_CODE} | egrep -q '^2'; then
-  REACTION_SYMBOL="confused"
-fi
+for url in $(cat url.data); do
+  # Execute the action.
+  # Store the response code in a variable.
+  # Store the answer in file .action-response.json.
+  RESPONSE_CODE=$(curl --write-out '%{http_code}' --silent --output .action-response.json --request POST \
+      --url "${url}" \
+      --header "authorization: Bearer ${GITHUB_TOKEN}" \
+      --header "content-type: application/json")
+
+  touch triggered.data
+  echo $url | sed -e 's|/api.github.com/repos/|/github.com/|' -e 's|/[^/]*$||' >> triggered.data
+
+  if ! echo ${RESPONSE_CODE} | egrep -q '^2'; then
+    REACTION_SYMBOL="confused"
+    RESPONSE_MESSAGE=$(jq -r '.message' .action-response.json)
+    send_comment "Oops, something went wrong:\n~~~\n${RESPONSE_MESSAGE}\n~~~\n"
+    break
+  fi
+  rm .action-response.json
+done
+
 send_reaction "${REACTION_SYMBOL}"
 
-# In case we received a non 2xx response code, relay the error message as a comment.
-if ! echo ${RESPONSE_CODE} | egrep -q '^2'; then
-  RESPONSE_MESSAGE=$(jq -r '.message' .action-response.json)
-  send_comment "Oops, something went wrong:\n~~~\n${RESPONSE_MESSAGE}\n~~~\n"
+cat triggered.data
+
+if [ -f "triggered.data" ]; then
+  RESPONSE_MESSAGE="The following workflows runs were triggered:\n$(cat triggered.data)"
+  send_comment "${RESPONSE_MESSAGE}"
 fi

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Re-Test Action
         uses: ./.github/actions/retest-action
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit e9587a9cdd15d522276bc4a00df827848e34d0be)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

All changes must adhere to this template to make it easy for reviewers
and preserve rationale/history behind every change
-->

## 📑 Description
<!-- Add a brief description of the pr -->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Additional Information for reviewers
<!--
What exactly did you change - you may also defer to information
contained in commit messages. At a bare minimum it's worth highlighting
which areas of the code were changed as it's easier to assign reviewers
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My code requires changes to the documentation
- [ ] if so, I have updated the documentation as required
- [ ] My code requires tests
- [ ] if so, I have added and/or updated the tests as required
- [ ] All the tests have passed in the CI <!-- If not leave a comment as to why the CI is red and if you need help understanding what's wrong -->

## How to verify it
<!--
Did you include unit tests? or end-to-end tests?
How can I manually verify that this patch achieves its objective
-->
